### PR TITLE
recurrent : rework graph inputs + add TODOs

### DIFF
--- a/src/llama-kv-cache-hybrid-recurrent.h
+++ b/src/llama-kv-cache-hybrid-recurrent.h
@@ -4,7 +4,6 @@
 #include "llama-graph.h"
 #include "llama-kv-cache-recurrent.h"
 #include "llama-kv-cache-unified.h"
-#include "llama-kv-cells.h"
 #include "llama-memory.h"
 
 #include <memory>
@@ -12,6 +11,7 @@
 
 //
 // llama_kv_cache_hybrid_recurrent
+// TODO: rename to llama_memory_hybrid
 //
 
 // utilizes instances of llama_kv_cache_recurrent and llama_kv_cache_unified to
@@ -93,9 +93,6 @@ private:
 
 class llama_kv_cache_hybrid_recurrent_state : public llama_memory_state_i {
 public:
-    using llama_kv_cache_unified_state_ptr   = std::unique_ptr<llama_kv_cache_unified_state>;
-    using llama_kv_cache_recurrent_state_ptr = std::unique_ptr<llama_kv_cache_recurrent_state>;
-
     // init failure
     explicit llama_kv_cache_hybrid_recurrent_state(llama_memory_status status);
 
@@ -104,8 +101,9 @@ public:
 
     // init update
     explicit llama_kv_cache_hybrid_recurrent_state(
-           llama_kv_cache_unified_state * state_unified,
-         llama_kv_cache_recurrent_state * state_recurrent);
+        llama_kv_cache_hybrid_recurrent * kv,
+                          llama_context * lctx,
+                                   bool   optimize);
 
     // init success
     llama_kv_cache_hybrid_recurrent_state(
@@ -132,7 +130,7 @@ public:
     const llama_kv_cache_recurrent_state * get_state_recurrent() const;
 
 private:
-    const llama_memory_status status;
+    llama_memory_status status;
 
     llama_sbatch sbatch;
 
@@ -141,6 +139,6 @@ private:
 
     std::vector<llama_ubatch> ubatches;
 
-    const llama_memory_state_ptr state_attn;
-    const llama_memory_state_ptr state_recurrent;
+    llama_memory_state_ptr state_attn;
+    llama_memory_state_ptr state_recurrent;
 };

--- a/src/llama-kv-cache-recurrent.cpp
+++ b/src/llama-kv-cache-recurrent.cpp
@@ -384,11 +384,11 @@ llama_memory_state_ptr llama_kv_cache_recurrent::init_batch(const llama_batch & 
         return std::make_unique<llama_kv_cache_recurrent_state>(LLAMA_MEMORY_STATUS_FAILED_PREPARE);
     }
 
-    return std::make_unique<llama_kv_cache_recurrent_state>(LLAMA_MEMORY_STATUS_SUCCESS, this, std::move(sbatch), std::move(ubatches));
+    return std::make_unique<llama_kv_cache_recurrent_state>(this, std::move(sbatch), std::move(ubatches));
 }
 
 llama_memory_state_ptr llama_kv_cache_recurrent::init_full() {
-    return std::make_unique<llama_kv_cache_recurrent_state>(LLAMA_MEMORY_STATUS_SUCCESS, this);
+    return std::make_unique<llama_kv_cache_recurrent_state>(this);
 }
 
 llama_memory_state_ptr llama_kv_cache_recurrent::init_update(llama_context * lctx, bool optimize) {
@@ -1043,15 +1043,13 @@ bool llama_kv_cache_recurrent::state_read_data(llama_io_read_i & io, uint32_t ce
 llama_kv_cache_recurrent_state::llama_kv_cache_recurrent_state(llama_memory_status status) : status(status) {}
 
 llama_kv_cache_recurrent_state::llama_kv_cache_recurrent_state(
-        llama_memory_status status,
-        llama_kv_cache_recurrent * kv) : status(status), kv(kv), is_full(true) {
+        llama_kv_cache_recurrent * kv) : status(LLAMA_MEMORY_STATUS_SUCCESS), kv(kv), is_full(true) {
 }
 
 llama_kv_cache_recurrent_state::llama_kv_cache_recurrent_state(
-        llama_memory_status status,
         llama_kv_cache_recurrent * kv,
         llama_sbatch sbatch,
-        std::vector<llama_ubatch> ubatches) : status(status), kv(kv), sbatch(std::move(sbatch)), ubatches(std::move(ubatches)) {}
+        std::vector<llama_ubatch> ubatches) : status(LLAMA_MEMORY_STATUS_SUCCESS), kv(kv), sbatch(std::move(sbatch)), ubatches(std::move(ubatches)) {}
 
 llama_kv_cache_recurrent_state::~llama_kv_cache_recurrent_state() = default;
 

--- a/src/llama-kv-cache-recurrent.h
+++ b/src/llama-kv-cache-recurrent.h
@@ -11,8 +11,10 @@
 // llama_kv_cache_recurrent
 //
 
-// TODO: extract the KV cache state used for graph computation into llama_kv_cache_recurrent_state_i
+// TODO: extract the cache state used for graph computation into llama_kv_cache_recurrent_state_i
 //       see the implementation of llama_kv_cache_unified_state_i for an example how to do it
+// TODO: avoid the notion of "KV cache" / "KV cells", etc.
+// TODO: rename to llama_recurrent_state / llama_recurrent_cache
 class llama_kv_cache_recurrent : public llama_memory_i {
 public:
 
@@ -131,12 +133,10 @@ public:
 
     // used to create a full-cache state
     llama_kv_cache_recurrent_state(
-            llama_memory_status status,
             llama_kv_cache_recurrent * kv);
 
     // used to create a state from a batch
     llama_kv_cache_recurrent_state(
-            llama_memory_status status,
             llama_kv_cache_recurrent * kv,
             llama_sbatch sbatch,
             std::vector<llama_ubatch> ubatches);

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -9116,7 +9116,7 @@ struct llm_build_mamba : public llm_graph_context {
         // {n_embd, n_tokens}
         inpL = build_inp_embd(model.tok_embd);
 
-        auto * rs_inp = build_rs_inp_recurrent();
+        auto * rs_inp = build_rs_inp();
 
         for (int il = 0; il < n_layer; ++il) {
             // norm
@@ -12092,7 +12092,7 @@ struct llm_build_rwkv6 : public llm_build_rwkv6_base {
         inpL = build_inp_embd(model.tok_embd);
         inpL = build_norm(inpL, model.tok_norm, model.tok_norm_b, LLM_NORM, -1);
 
-        auto * rs_inp = build_rs_inp_recurrent();
+        auto * rs_inp = build_rs_inp();
 
         const auto n_embd = hparams.n_embd;
         const auto n_seq_tokens = ubatch.n_seq_tokens;
@@ -12187,7 +12187,7 @@ struct llm_build_rwkv6qwen2 : public llm_build_rwkv6_base {
 
         inpL = build_inp_embd(model.tok_embd);
 
-        auto * rs_inp = build_rs_inp_recurrent();
+        auto * rs_inp = build_rs_inp();
 
         const auto n_embd = hparams.n_embd;
         const auto n_seq_tokens = ubatch.n_seq_tokens;
@@ -12441,7 +12441,7 @@ struct llm_build_rwkv7 : public llm_build_rwkv7_base {
         inpL = build_inp_embd(model.tok_embd);
         inpL = build_norm(inpL, model.tok_norm, model.tok_norm_b, LLM_NORM, -1);
 
-        auto * rs_inp = build_rs_inp_recurrent();
+        auto * rs_inp = build_rs_inp();
 
         const auto n_embd = hparams.n_embd;
         const auto n_seq_tokens = ubatch.n_seq_tokens;
@@ -12532,7 +12532,7 @@ struct llm_build_arwkv7 : public llm_build_rwkv7_base {
 
         inpL = build_inp_embd(model.tok_embd);
 
-        auto * rs_inp = build_rs_inp_recurrent();
+        auto * rs_inp = build_rs_inp();
 
         const auto n_embd = hparams.n_embd;
         const auto n_seq_tokens = ubatch.n_seq_tokens;


### PR DESCRIPTION
The diff is a bit confusing because I also moved the definitions in `llama-graph.cpp` to follow the order of the declarations in `llama-graph.h`.