### PR TITLE
Nemotron-H: MLP gate cleanup

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -3253,9 +3253,7 @@ bool llama_model::load_tensors(llama_model_loader & ml) {
                     const uint32_t v_dim              = head_dim;
                     const int64_t num_attention_heads = hparams.n_head();
                     const int64_t q_num_heads         = num_attention_heads;
-                    const int64_t dt_dim              = hparams.ssm_dt_rank > 0
-                        ? hparams.ssm_dt_rank
-                        : std::max<int64_t>(64, hparams.n_embd / 16);
+                    const int64_t dt_dim              = std::max(64, int(hparams.n_embd / 16));
 
                     tok_embd = create_tensor(tn(LLM_TENSOR_TOKEN_EMBD, "weight"), {n_embd, n_vocab}, 0);
 
@@ -17265,9 +17263,7 @@ private:
             cb(x_bcdt, "mamba_bcdt_proj", il);
 
             // split into dt, B, C
-            const int64_t dt_dim = hparams.ssm_dt_rank > 0
-                ? hparams.ssm_dt_rank
-                : std::max<int64_t>(64, hparams.n_embd / 16);
+            const int64_t dt_dim = std::max(64, int(hparams.n_embd / 16));
             ggml_tensor * B = ggml_view_3d(ctx0, x_bcdt, d_state, n_seq_tokens, n_seqs, x_bcdt->nb[1], x_bcdt->nb[2], 0);
             ggml_tensor * C  = ggml_view_3d(ctx0, x_bcdt, d_state, n_seq_tokens, n_seqs, x_bcdt->nb[1], x_bcdt->nb[2], ggml_element_size(x_bcdt)*d_state);
             ggml_tensor * dt  = ggml_view_3d(ctx0, x_bcdt, dt_dim, n_seq_tokens, n_seqs, x_bcdt->nb[1], x_bcdt->nb[2], ggml_element_size(x_bcdt)*(2*d_state));

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -3253,7 +3253,9 @@ bool llama_model::load_tensors(llama_model_loader & ml) {
                     const uint32_t v_dim              = head_dim;
                     const int64_t num_attention_heads = hparams.n_head();
                     const int64_t q_num_heads         = num_attention_heads;
-                    const int64_t dt_dim              = std::max(64, int(hparams.n_embd / 16));
+                    const int64_t dt_dim              = hparams.ssm_dt_rank > 0
+                        ? hparams.ssm_dt_rank
+                        : std::max<int64_t>(64, hparams.n_embd / 16);
 
                     tok_embd = create_tensor(tn(LLM_TENSOR_TOKEN_EMBD, "weight"), {n_embd, n_vocab}, 0);
 
@@ -17263,7 +17265,9 @@ private:
             cb(x_bcdt, "mamba_bcdt_proj", il);
 
             // split into dt, B, C
-            const int64_t dt_dim = std::max(64, int(hparams.n_embd / 16));
+            const int64_t dt_dim = hparams.ssm_dt_rank > 0
+                ? hparams.ssm_dt_rank
+                : std::max<int64_t>(64, hparams.n_embd / 16);
             ggml_tensor * B = ggml_view_3d(ctx0, x_bcdt, d_state, n_seq_tokens, n_seqs, x_bcdt->nb[1], x_bcdt->nb[2], 0);
             ggml_tensor * C  = ggml_view_3d(ctx0, x_bcdt, d_state, n_seq_tokens, n_seqs, x_bcdt->nb[1], x_bcdt->nb[2], ggml_element_size(x_bcdt)*d_state);
             ggml_tensor * dt  = ggml_view_3d(ctx0, x_bcdt, dt_dim, n_seq_tokens, n_seqs, x_bcdt->nb[1], x_bcdt->nb[2], ggml_element_size(x_bcdt)*(2*d_state));

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -14339,11 +14339,11 @@ struct llm_build_nemotronh : public llm_graph_context_mamba {
 
         cur = build_ffn(cur,
                 model.layers[il].ffn_up,   model.layers[il].ffn_up_b,   NULL,
-                model.layers[il].ffn_gate, model.layers[il].ffn_gate_b, NULL,
+                NULL,                      NULL,                        NULL,
                 model.layers[il].ffn_down, model.layers[il].ffn_down_b, NULL,
                 NULL,
                 LLM_FFN_RELU_SQR, LLM_FFN_PAR, il);
-                cb(cur, "ffn_out", il);
+        cb(cur, "ffn_out", il);
 
         cur = build_cvec(cur, il);
         cb(cur, "l_out", il);


### PR DESCRIPTION
Summary:

- MLP cleanup for Nemotron-H: pass NULL for unused gate tensors.

Changes:

- MLP gate cleanup: `src/llama-model.cpp:14337` — in `llm_build_nemotronh::build_ffn_layer`, pass `NULL` for gate tensors to make it explicit the MLP has no gate.

Deferred (out of scope here):

- Hybrid GGUF metadata, block_type array, and hybrid caches plumbing.
- Causal Conv1D padding tweaks beyond the default `d_conv - 1` (kept as-is).
- MLP activation as an hparam (Nemotron-H remains `LLM_FFN_RELU_SQR`).

Status:

- Converts and loads; generation works. Sample output below.

Sample generation

```
main: prompt: '<SPECIAL_10>System

<SPECIAL_11>User
/no_think Write a haiku about GPUs
<SPECIAL_11>Assistant
<think></think>'
main: number of tokens in prompt = 26
     1 -> '<s>'
    10 -> '<SPECIAL_10>'
  6775 -> 'System'
  1267 -> '

'
    11 -> '<SPECIAL_11>'
  4019 -> 'User'
  1010 -> '
'
 75010 -> '/no'
 31180 -> '_th'
  2077 -> 'ink'
 27040 -> ' Write'
  1261 -> ' a'
  3944 -> ' ha'
 15636 -> 'iku'
  2314 -> ' about'
 20534 -> ' GP'
  7176 -> 'Us'
  1010 -> '
'
    11 -> '<SPECIAL_11>'
102897 -> 'Assistant'
  1010 -> '
'
 49250 -> '<th'
  2077 -> 'ink'
  4468 -> '></'
 74045 -> 'think'
  1062 -> '>'

sampler seed: 3146942522
sampler params: 
	repeat_last_n = 64, repeat_penalty = 1,000, frequency_penalty = 0,000, presence_penalty = 0,000
	dry_multiplier = 0,000, dry_base = 1,750, dry_allowed_length = 2, dry_penalty_last_n = 4096
	top_k = 40, top_p = 0,950, min_p = 0,050, xtc_probability = 0,000, xtc_threshold = 0,100, typical_p = 1,000, top_n_sigma = -1,000, temp = 0,800
	mirostat = 0, mirostat_lr = 0,100, mirostat_ent = 5,000
sampler chain: logits -> logit-bias -> penalties -> dry -> top-n-sigma -> top-k -> typical -> top-p -> min-p -> xtc -> temp-ext -> dist 
generate: n_ctx = 4096, n_batch = 2048, n_predict = 128, n_keep = 1

System

User
/no_think Write a haiku about GPUs
Assistant
<think></think>Silicon hearts beat,
Light-speed math in parallel,
GPUs dream in pixels.
 [end of text]
```

Addresses https://github.com/ggml-org/llama.cpp/issues/15409 - Feature Request: Support for NVidia Nemotron Nano v2